### PR TITLE
fixed stuck test due to werkzeug conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.27.0
 sciencebeam-utils==0.1.4
 tqdm==4.62.3
 typing-extensions==4.0.1
+Werkzeug>=2.0.0,<2.1.0


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/237

stuck at:

```
19:42:50  running pytest
19:42:51  ============================= test session starts ==============================
19:42:51  platform linux -- Python 3.7.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
19:42:51  rootdir: /srv/sciencebeam-pipelines, configfile: pytest.ini, testpaths: tests
19:42:51  collected 196 items
19:42:51  
19:42:52  tests/config/app_config_test.py .........                                [  4%]
19:42:52  tests/examples/grobid_service_pdf_to_xml_test.py .                       [  5%]
19:42:54  tests/pipeline_runners/beam_pipeline_runner_test.py ............. * Serving Flask app 'tests.utils.mock_server' (lazy loading)
19:42:54   * Environment: production
19:42:54     WARNING: This is a development server. Do not use it in a production deployment.
19:42:54     Use a production WSGI server instead.
19:42:54   * Debug mode: off
```